### PR TITLE
[Update]Supports gcc compilation for nrf52 RT-Thread bsp

### DIFF
--- a/mdk/gcc_startup_nrf52.S
+++ b/mdk/gcc_startup_nrf52.S
@@ -251,7 +251,6 @@ Reset_Handler:
  *
  * All addresses must be aligned to 4 bytes boundary.
  */
-#ifdef __STARTUP_CLEAR_BSS
     ldr r1, =__bss_start__
     ldr r2, =__bss_end__
 
@@ -266,7 +265,6 @@ Reset_Handler:
     bgt .L_loop3
 
 .L_loop3_done:
-#endif /* __STARTUP_CLEAR_BSS */
 
 /* Execute SystemInit function. */
     bl SystemInit
@@ -277,7 +275,7 @@ Reset_Handler:
 #ifndef __START
 #define __START _start
 #endif
-    bl __START
+    bl entry
 
     .pool
     .size   Reset_Handler,.-Reset_Handler

--- a/mdk/gcc_startup_nrf52840.S
+++ b/mdk/gcc_startup_nrf52840.S
@@ -251,7 +251,6 @@ Reset_Handler:
  *
  * All addresses must be aligned to 4 bytes boundary.
  */
-#ifdef __STARTUP_CLEAR_BSS
     ldr r1, =__bss_start__
     ldr r2, =__bss_end__
 
@@ -266,7 +265,6 @@ Reset_Handler:
     bgt .L_loop3
 
 .L_loop3_done:
-#endif /* __STARTUP_CLEAR_BSS */
 
 /* Execute SystemInit function. */
     bl SystemInit
@@ -277,7 +275,7 @@ Reset_Handler:
 #ifndef __START
 #define __START _start
 #endif
-    bl __START
+    bl entry
 
     .pool
     .size   Reset_Handler,.-Reset_Handler

--- a/mdk/nrf_common.ld
+++ b/mdk/nrf_common.ld
@@ -73,6 +73,30 @@ SECTIONS
         *(.rodata*)
 
         KEEP(*(.eh_frame*))
+	        /* section information for finsh shell */
+        . = ALIGN(4);
+        __fsymtab_start = .;
+        KEEP(*(FSymTab))
+        __fsymtab_end = .;
+
+        . = ALIGN(4);
+        __vsymtab_start = .;
+        KEEP(*(VSymTab))
+        __vsymtab_end = .;
+
+        /* section information for initial. */
+        . = ALIGN(4);
+        __rt_init_start = .;
+        KEEP(*(SORT(.rti_fn*)))
+        __rt_init_end = .;
+
+        . = ALIGN(4);
+
+        PROVIDE(__ctors_start__ = .);
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        PROVIDE(__ctors_end__ = .);
+
     } > FLASH
 
     .ARM.extab :


### PR DESCRIPTION
兼容RT-Thread的nrf52832和nrf52840 bsp使用gcc编译